### PR TITLE
chore: upgrade python runtime

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ module "lambda" {
 
   handler                        = "notify_teams.lambda_handler"
   source_path                    = "${path.module}/functions/notify_teams.py"
-  runtime                        = "python3.6"
+  runtime                        = "python3.9"
   timeout                        = 30
   kms_key_arn                    = var.kms_key_arn
   reserved_concurrent_executions = var.reserved_concurrent_executions


### PR DESCRIPTION
Upgrade python runtime to fix the following errors:
``` 
Error: error creating Lambda Function (1): InvalidParameterValueException: The runtime parameter of python3.6 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.9) while creating or updating functions.
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: "5031a931-cf95-4e01-9d79-60bcc182b162"
  },
  Message_: "The runtime parameter of python3.6 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.9) while creating or updating functions.",
  Type: "User"
}
```